### PR TITLE
Formulaires

### DIFF
--- a/tpl/archive.html
+++ b/tpl/archive.html
@@ -25,8 +25,8 @@
 
   <form action="{{tpl:BlogURL}}" method="get" id="search-form" role="search">
     <p class="search field">
-      <label for="q"></label>{{tpl:lang Search in}} {{tpl:BlogName encode_html="1"}}<br />
-      <input class="text" type="text" size="15" maxlength="255" id="q" name="q" value="" />
+      <span id="q">{{tpl:lang Search in}} {{tpl:BlogName encode_html="1"}}</span><br />
+      <input class="text" type="text" size="15" maxlength="255" aria-labelledby="q" name="q" value="" />
       <input class="submit" type="submit" value="ok" />
     </p>
   </form>

--- a/tpl/contact_me.html
+++ b/tpl/contact_me.html
@@ -28,15 +28,14 @@
     <tpl:ContactMeIf sent="0">
       {{tpl:ContactMeFormCaption}}
       <form action="{{tpl:ContactMeURL}}" method="post" id="comment-form" class="contactme">
-        <fieldset>
           <p class="field"><label for="c_name">{{tpl:lang Name or nickname}}&nbsp;:</label>
           <input name="c_name" id="c_name" type="text" size="30" maxlength="255"
-          value="{{tpl:ContactMeName encode_html="1"}}" />
+          value="{{tpl:ContactMeName encode_html="1"}}"required />
           </p>
 
-          <p class="field"><label for="c_mail">{{tpl:lang Email address}}&nbsp;:</label>
-          <input name="c_mail" id="c_mail" type="text" size="30" maxlength="255"
-          value="{{tpl:ContactMeEmail encode_html="1"}}" />
+          <p class="field"><label for="c_mail">{{tpl:lang Email address}} (example@example.org)&nbsp;:</label>
+          <input name="c_mail" id="c_mail" type="email" size="30" maxlength="255"
+          value="{{tpl:ContactMeEmail encode_html="1"}}" autocomplete="email" required />
           </p>
 
           <p class="field"><label for="c_site">{{tpl:lang Website}}
@@ -47,7 +46,7 @@
 
           <p class="field"><label for="c_subject">{{tpl:lang Subject}}&nbsp;:</label>
           <input name="c_subject" id="c_subject" type="text" size="30" maxlength="255"
-          value="{{tpl:ContactMeSubject encode_html="1"}}" />
+          value="{{tpl:ContactMeSubject encode_html="1"}}" required />
           </p>
 
           <p style="display:none"><input name="f_mail" type="text" size="30"
@@ -55,11 +54,10 @@
 
           <p class="field"><label for="c_message">{{tpl:lang Message}}&nbsp;:</label>
           <textarea name="c_message" id="c_message" cols="35"
-          rows="7">{{tpl:ContactMeMessage raw="1" encode_html="1"}}</textarea>
+          rows="7" required>{{tpl:ContactMeMessage raw="1" encode_html="1"}}</textarea>
           </p>
 
           <p><input type="submit" class="submit" value="{{tpl:lang send}}" /></p>
-        </fieldset>
       </form>
     </tpl:ContactMeIf>
 

--- a/tpl/page.html
+++ b/tpl/page.html
@@ -135,23 +135,22 @@
       </tpl:IfCommentPreview>
 
       <h3>{{tpl:lang Add a comment}}</h3>
-      <fieldset>
         <!-- # --BEHAVIOR-- publicCommentFormBeforeContent -->
         {{tpl:SysBehavior behavior="publicCommentFormBeforeContent"}}
 
         <p class="field"><label for="c_name">{{tpl:lang Name or nickname}}&nbsp;:</label>
           <input name="c_name" id="c_name" type="text" size="30" maxlength="255"
-           value="{{tpl:CommentPreviewName encode_html="1"}}" />
+           value="{{tpl:CommentPreviewName encode_html="1"}}" required />
         </p>
 
-        <p class="field"><label for="c_mail">{{tpl:lang Email address}}&nbsp;:</label>
-          <input name="c_mail" id="c_mail" type="text" size="30" maxlength="255"
-           value="{{tpl:CommentPreviewEmail encode_html="1"}}" />
+        <p class="field"><label for="c_mail">{{tpl:lang Email address}} (example@example.org) &nbsp;:</label>
+          <input name="c_mail" id="c_mail" type="email" size="30" maxlength="255"
+           value="{{tpl:CommentPreviewEmail encode_html="1"}}" autocomplete="email" required />
         </p>
 
         <p class="field"><label for="c_site">{{tpl:lang Website}} ({{tpl:lang optional}})&nbsp;:</label>
           <input name="c_site" id="c_site" type="text" size="30" maxlength="255"
-           value="{{tpl:CommentPreviewSite encode_html="1"}}" />
+           value="{{tpl:CommentPreviewSite encode_html="1"}}" required />
         </p>
 
         <p style="display:none">
@@ -160,14 +159,13 @@
 
         <p class="field"><label for="c_content">{{tpl:lang Comment}}&nbsp;:</label>
           <textarea name="c_content" id="c_content" cols="35"
-           rows="7">{{tpl:CommentPreviewContent raw="1" encode_html="1"}}</textarea>
+           rows="7" aria-describedby="form-help" required>{{tpl:CommentPreviewContent raw="1" encode_html="1"}}</textarea>
         </p>
 
-        <p class="form-help">{{tpl:CommentHelp}}</p>
+        <p class="form-help" id="form-help">{{tpl:CommentHelp}}</p>
 
         <!-- # --BEHAVIOR-- publicCommentFormAfterContent -->
         {{tpl:SysBehavior behavior="publicCommentFormAfterContent"}}
-      </fieldset>
 
       <fieldset>
         <p class="buttons">

--- a/tpl/post.html
+++ b/tpl/post.html
@@ -162,18 +162,18 @@
       </tpl:IfCommentPreview>
 
       <h3>{{tpl:lang Add a comment}}</h3>
-      <fieldset>
+      
         <!-- # --BEHAVIOR-- publicCommentFormBeforeContent -->
         {{tpl:SysBehavior behavior="publicCommentFormBeforeContent"}}
 
         <p class="field"><label for="c_name">{{tpl:lang Name or nickname}}&nbsp;:</label>
           <input name="c_name" id="c_name" type="text" size="30" maxlength="255"
-           value="{{tpl:CommentPreviewName encode_html="1"}}" />
+           value="{{tpl:CommentPreviewName encode_html="1"}}" required />
         </p>
 
-        <p class="field"><label for="c_mail">{{tpl:lang Email address}}&nbsp;:</label>
+        <p class="field"><label for="c_mail">{{tpl:lang Email address}} (example@example.org)&nbsp;:</label>
           <input name="c_mail" id="c_mail" type="text" size="30" maxlength="255"
-           value="{{tpl:CommentPreviewEmail encode_html="1"}}" />
+           value="{{tpl:CommentPreviewEmail encode_html="1"}}" autocomplete="email" required />
         </p>
 
         <p class="field"><label for="c_site">{{tpl:lang Website}} ({{tpl:lang optional}})&nbsp;:</label>
@@ -187,14 +187,14 @@
 
         <p class="field"><label for="c_content">{{tpl:lang Comment}}&nbsp;:</label>
           <textarea name="c_content" id="c_content" cols="35"
-           rows="7">{{tpl:CommentPreviewContent raw="1" encode_html="1"}}</textarea>
+           rows="7" aria-describedby="form-help" required>{{tpl:CommentPreviewContent raw="1" encode_html="1"}}</textarea>
         </p>
 
-        <p class="form-help">{{tpl:CommentHelp}}</p>
+        <p class="form-help" id="form-help">{{tpl:CommentHelp}}</p>
 
         <!-- # --BEHAVIOR-- publicCommentFormAfterContent -->
         {{tpl:SysBehavior behavior="publicCommentFormAfterContent"}}
-      </fieldset>
+      
 
       <fieldset>
         <p class="buttons">


### PR DESCRIPTION
Sur archive.html : corrige label vide. Étiquettage avec aria-labelledby.

Sur contact, post et page : 
- ajout attribut required pour contrôle de saisie avant la prévisualisation ;
- champ email : 
 1. ajout indication de format obligatoire pour champ email ;
 1. ajout type="email" ;
 1. ajout attribut autocomplete="email"  pour conformité au critère 11.13 ;
- ajout aria-describedby pour relier message d'aide sur textarea ;
- supression fieldset inutiles.